### PR TITLE
Added github link to welcome section

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
 						<p><i>A scalable drop-in Real-time as a Service that abstracts away the complexity of real-time communication and provides connection state recovery</i></p>
 						<ul class="actions">
 							<li><a href="#four" class="button scrolly">See the case study</a></li>
+							<li><a href="https://github.com/twine-realtime" class="button scrolly">Github</a></li>
 						</ul>
 					</div>
 				</section>


### PR DESCRIPTION
Adding a button to link Twine's github. It's in the welcome section of the site, right next to the "see the case study" button.